### PR TITLE
Improve XMLTestRunLogger API compatibility

### DIFF
--- a/tests/XMLTestRunLoggerTest.m
+++ b/tests/XMLTestRunLoggerTest.m
@@ -32,6 +32,25 @@ classdef XMLTestRunLoggerTest < TestCaseInDir
             end
         end
 
+        function testLogsResultsToFileIdentifier(self)
+            fileIdentifier = fopen(self.testResultsFilename, 'w');
+            fileCloser = onCleanup(@() fclose(fileIdentifier));
+
+            logger = XMLTestRunLogger(fileIdentifier);
+            suite = TestSuite('TwoPassingTests');
+            suite.run(logger);
+
+            % The XMLTestRunLogger should have created the correct output file
+            assertTrue(self.resultTargetExists());
+
+            % And the resulting file should contain the correct results
+            testResults = xml_read(self.testResultsFilename);
+            assertEqual(testResults.ATTRIBUTE.tests, 2);
+            assertEqual(testResults.ATTRIBUTE.errors, 0);
+            assertEqual(testResults.ATTRIBUTE.failures, 0);
+            assertEqual(testResults.ATTRIBUTE.skip, 0);
+        end
+
         function testLogsResultsToFilename(self)
             logger = XMLTestRunLogger(self.testResultsFilename);
             suite = TestSuite('TwoPassingTests');


### PR DESCRIPTION
The `XMLTestRunLogger` class accepts a string specifying a filename to output the XML logs to. However most of the other test run loggers, such as the descendants from `TestRunDisplay` accept a file identifier instead. To be able to easily substitute the different test run loggers other, this pull request changes the `XMLTestRunLogger` API so that it supports both options.

It also adds some tests to verify that both the old and new behavior works as expected.
