### PR TITLE
Allow definition of parameterized tests by subclassing TestSuite

### DIFF
--- a/src/+xunit/+utils/isTestSuiteSubclass.m
+++ b/src/+xunit/+utils/isTestSuiteSubclass.m
@@ -1,0 +1,9 @@
+function tf = isTestSuiteSubclass(name)
+
+class_meta = meta.class.fromName(name);
+if isempty(class_meta)
+    % Not the name of a class
+    tf = false;
+else
+    tf = class_meta < ?TestSuite;
+end

--- a/src/TestSuite.m
+++ b/src/TestSuite.m
@@ -231,8 +231,11 @@ classdef TestSuite < TestComponent
             if xunit.utils.isTestCaseSubclass(name)
                 suite = TestSuite.fromTestCaseClassName(name);
                 
+            elseif xunit.utils.isTestSuiteSubclass(name)
+                suite = feval(name);
+                
             elseif ~isempty(meta.class.fromName(name))
-                % Input is the name of a class that is not a TestCase subclass.
+                % Input is the name of a class that is not a TestCase or TestSuite subclass.
                 % Return an empty test suite.
                 suite = TestSuite();
                 suite.Name = name;

--- a/src/TestSuite.m
+++ b/src/TestSuite.m
@@ -373,6 +373,8 @@ classdef TestSuite < TestComponent
                 class_names{k} = class_name;
                 if xunit.utils.isTestCaseSubclass(class_name)
                     test_suite.add(TestSuite.fromTestCaseClassName(class_name));
+                elseif xunit.utils.isTestSuiteSubclass(class_name)
+                    test_suite.add(feval(class_name));
                 end
             end
             

--- a/tests/+xunit/+mocktests/C.m
+++ b/tests/+xunit/+mocktests/C.m
@@ -1,0 +1,37 @@
+% Class C is a TestSuite subclass containing two test cases (test_a and test_b).
+classdef C < TestSuite
+    methods
+        function self = C()
+            self = self@TestSuite();
+            self.Name = class(self);
+            self.Location = fileparts(which(class(self)));
+            
+            names = {'test_a'; 'test_b'};
+            
+            testCases = self.createTestCases(names);
+            self.add(testCases);
+        end
+        
+        function testCases = createTestCases(self, names)
+            testCases = cell(1, size(names, 1));
+            for idx = 1:size(names, 1)
+                testCases{idx} = self.createTestCase(names{idx, 1});
+            end
+        end
+        
+        function testCase = createTestCase(self, name)
+            %CREATETESTCASE Creates a function handle test case for a given test case
+            
+            % Create TestCase object
+            testFcn     = @() [];
+            setupFcn    = [];
+            teardownFcn = [];
+            
+            testCase    = FunctionHandleTestCase(testFcn, setupFcn, teardownFcn);
+            
+            % Set name and location of test from name of file
+            testCase.Name     = name;
+            testCase.Location = which(class(self));
+        end
+    end
+end

--- a/tests/TestParameterizedTests.m
+++ b/tests/TestParameterizedTests.m
@@ -1,0 +1,46 @@
+%TestParameterizedTests Unit tests for sub-classing the TestSuite class.
+
+classdef TestParameterizedTests < TestCaseInDir
+    methods
+        function self = TestParameterizedTests(name)
+            self = self@TestCaseInDir(name, ...
+                fullfile(fileparts(which(mfilename)), 'helper_classes'));
+        end
+        
+        function testConstructor(~)
+            % Exercise the constructor.  Verify that the Name and Location
+            % properties are set correctly.
+            ts = TestParameterizedSuite();
+            assertEqual(ts.Name, 'TestParameterizedSuite');
+            assertEqual(ts.Location, which('TestParameterizedSuite'));
+            assertEqual(numel(ts.TestComponents), 3);
+        end
+        
+        function testPassingTest(~)
+            logger = TestRunLogger();
+            suite = TestParameterizedSuite();
+            tc = findTestComponent(suite, 'test_sin_0deg');
+            tc.run(logger);
+            assertEqual(logger.NumFailures, 0)
+        end
+        
+        function testFailingTest(~)
+            logger = TestRunLogger();
+            suite = TestParameterizedSuite();
+            tc = findTestComponent(suite, 'test_sin_90deg');
+            tc.run(logger);
+            assertEqual(logger.NumFailures, 1)
+        end
+    end
+end
+
+function theTestComponent = findTestComponent(suite, name)
+% Find the TestComponent given a name of a function under test.
+
+componentNames = cellfun(@(x) x.Name, suite.TestComponents, 'UniformOutput', false);
+index = find(strcmp(name, componentNames), 1);
+assertTrue(~ isempty(index), ['Could not find test component for ' name]);
+
+theTestComponent = suite.TestComponents{index};
+
+end

--- a/tests/TestSuiteTest.m
+++ b/tests/TestSuiteTest.m
@@ -117,9 +117,7 @@ classdef TestSuiteTest < TestCaseInDir
           % test components.
           suite = TestSuite.fromPwd();
           assertTrue(isa(suite, 'TestSuite'));
-          assertTrue(numel(suite.TestComponents) == 16);
+          assertEqual(numel(suite.TestComponents), 17);
       end
-      
    end
-
 end

--- a/tests/helper_classes/TestParameterizedSuite.m
+++ b/tests/helper_classes/TestParameterizedSuite.m
@@ -1,0 +1,46 @@
+classdef TestParameterizedSuite < TestSuite
+    methods
+        function this = TestParameterizedSuite()
+            this = this@TestSuite();
+            this.Name = class(this);
+            this.Location = which(class(this));
+            
+            values = {0, 0; 30 0.5; 90 0.8};
+            
+            testCases = this.createTestCases(values);
+            this.add(testCases);
+        end
+        
+        function testCases = createTestCases(this, values)
+            testCases = cell(1, size(values, 1));
+            for idx = 1:size(values, 1)
+                testCases{idx} = this.createTestCase(values{idx, 1}, values{idx, 2});
+            end
+        end
+        
+        function testCase = createTestCase(this, x, y)
+            %CREATETESTCASE Creates a function handle test case for a given test case
+            
+            % Create TestCase object
+            testFcn     = @() TestParameterizedSuite.checkResult(x, y);
+            setupFcn    = [];
+            teardownFcn = [];
+            
+            testCase    = FunctionHandleTestCase(testFcn, setupFcn, teardownFcn);
+            
+            % Set name and location of test from name of file
+            testCase.Name     = this.makeTestName(x);
+            testCase.Location = this.Location;
+        end
+        function str = makeTestName(this, x) %#ok<MANU>
+            str = sprintf('test_sin_%.0fdeg', x);
+            str = genvarname(str);
+        end
+    end
+    
+    methods (Static)
+        function checkResult(x, y)
+            assertElementsAlmostEqual(sind(x), y, 'absolute', 1e-9)
+        end
+    end
+end

--- a/tests/testIsTestSuiteSubclass.m
+++ b/tests/testIsTestSuiteSubclass.m
@@ -1,0 +1,21 @@
+classdef testIsTestSuiteSubclass < TestCase
+    %testIsTestSuiteSubclass Unit tests for isTestSuiteSubclass
+    
+    methods
+        function self = testIsTestSuiteSubclass(name)
+            self = self@TestCase(name);
+        end
+        
+        function testTestSuite(~)
+            assertEqual(false, xunit.utils.isTestSuiteSubclass('TestSuite'));
+        end
+        
+        function testSubclass(~)
+            assertEqual(true, xunit.utils.isTestSuiteSubclass('xunit.mocktests.C'));
+        end
+        
+        function testNotASubclass(~)
+            assertEqual(false, xunit.utils.isTestSuiteSubclass('atan2'));
+        end
+    end
+end

--- a/tests/test_packageName.m
+++ b/tests/test_packageName.m
@@ -5,12 +5,15 @@ testSuite = buildFunctionHandleTestSuite(localFunctionHandles);
 
 function test_happyCase
 suite = TestSuite.fromPackageName('xunit.mocktests');
-assertEqual(numel(suite.TestComponents), 5);
+assertEqual(numel(suite.TestComponents), 6);
 
 theTestComponent = findTestComponent(suite, 'xunit.mocktests.subpkg');
 assertEqual(numel(theTestComponent.TestComponents), 1);
 
 theTestComponent = findTestComponent(suite, 'xunit.mocktests.A');
+assertEqual(numel(theTestComponent.TestComponents), 2);
+
+theTestComponent = findTestComponent(suite, 'xunit.mocktests.C');
 assertEqual(numel(theTestComponent.TestComponents), 2);
 
 theTestComponent = findTestComponent(suite, 'xunit.mocktests.FooTest');
@@ -33,8 +36,8 @@ function theTestComponent = findTestComponent(suite, name)
 % This is needed because meta.package.fromName() doesn't sort its list of
 % functions, so the ordering isn't always stable.
 
-components = [suite.TestComponents{:}];
-index = find(strcmp(name, {components.Name}), 1);
+componentNames = cellfun(@(x) x.Name, suite.TestComponents, 'UniformOutput', false);
+index = find(strcmp(name, componentNames), 1);
 assertTrue(~ isempty(index), ['Could not find test component for ' name]);
 
 theTestComponent = suite.TestComponents{index};


### PR DESCRIPTION
The main updates are to allow parameterized tests to be defined by subclassing TestSuite.
Some other minor updates such as extracting functions from TestRunDisplay into utilities directory. Note that this directory also needs to be added on the path.

Example of parametrized tests in `tests\helper_classes\TestParameterizedSuite`.
