### PR TITLE
Replace `nargchk` with `narginchk`

### DIFF
--- a/src/+xunit/+utils/parseFloatAssertInputs.m
+++ b/src/+xunit/+utils/parseFloatAssertInputs.m
@@ -9,7 +9,7 @@ function params = parseFloatAssertInputs(varargin)
 %   Steven L. Eddins
 %   Copyright 2008-2009 The MathWorks, Inc.
 
-error(nargchk(2, 6, nargin, 'struct'));
+narginchk(2, 6);
 
 params = struct('A', {[]}, 'B', {[]}, 'ToleranceType', {[]}, ...
     'Tolerance', {[]}, 'FloorTolerance', {[]}, 'Message', {''});

--- a/tests/test_parseFloatAssertInputs.m
+++ b/tests/test_parseFloatAssertInputs.m
@@ -4,12 +4,12 @@ initTestSuite;
 %===============================================================================
 function test_tooFewInputs()
 assertExceptionThrown(@() xunit.utils.parseFloatAssertInputs(), ...
-    'MATLAB:nargchk:notEnoughInputs');
+    'MATLAB:narginchk:notEnoughInputs');
 
 %===============================================================================
 function test_tooManyInputs()
 assertExceptionThrown(@() xunit.utils.parseFloatAssertInputs(1,2,3,4,5,6,7), ...
-    'MATLAB:nargchk:tooManyInputs');
+    'MATLAB:narginchk:tooManyInputs');
 
 %===============================================================================
 function test_twoInputs()


### PR DESCRIPTION
`nargchk` will be removed in a future version of MATLAB in favor of the
more specific `narginchk` and `nargoutchk` as evidenced by
https://mathworks.com/help/matlab/ref/nargchk.html.