### PR TITLE
Verify more extensively whether a 'name' is actually a path in `fromName`

### DIFF
--- a/src/TestSuite.m
+++ b/src/TestSuite.m
@@ -197,9 +197,30 @@ classdef TestSuite < TestComponent
             %   named 'testA' found in the TestCase subclass MyTests.
             
             if isdir(name)
-                suite = TestSuiteInDir(name);
-                suite.gatherTestCases();
-                return;
+                % The provided name could be a path. However due to the way
+                % MATLAB works it could also be a partial path somewhere on the
+                % MATLAB path. To make sure we only operate on actual folders
+                % some additional logic is necessary
+                folderContents = what(name);
+
+                % Actually existing paths will only return a single element
+                % (cases exist where multiple values are returned, e.g.
+                % what('matlab')). Furthermore the path could be an absolute
+                % path or relative to the current working directory.
+                if numel(folderContents) == 1
+                    if strcmp(name, folderContents.path)
+                        suite = TestSuiteInDir(folderContents.path);
+                        suite.gatherTestCases();
+                        return;
+                    else
+                        relativePath = fullfile(pwd(), name);
+                        if isdir(relativePath)
+                            suite = TestSuiteInDir(relativePath);
+                            suite.gatherTestCases();
+                            return;
+                        end
+                    end
+                end
             end
             
             [name, filter_string] = strtok(name, ':');

--- a/tests/TestSuiteTest.m
+++ b/tests/TestSuiteTest.m
@@ -96,6 +96,20 @@ classdef TestSuiteTest < TestCaseInDir
          assertEqual(suite.Location, cwd_test_dir);
          assertEqual(numel(suite.TestComponents), 3);
       end
+
+      function test_fromName_with_relative_dirname_on_path(self)
+         % Passing a partial directory name that is on the MATLAB path will
+         % cause a crash if not handled properly, see #14. The 'matlab' package
+         % here is used as that will exist multiple times with respect to
+         % `what` used internally. The case for relative paths is implicitly
+         % tested, as that will make other tests in the test suite of this
+         % package fail.
+         suite = TestSuite.fromName('matlab');
+
+         assertEqual(suite.Name, 'matlab');
+         assertEqual(suite.Location, 'Package');
+         assertEqual(numel(suite.TestComponents), 0);
+      end
       
       function test_fromPwd(self)
           % Verify that the fromPwd method returns a nonempty TestSuite object


### PR DESCRIPTION
As noted in #14, cases exist where `isdir` will return true where it is not necessarily expected to do so. This is most evident when providing a partial path that happens to be on the MATLAB path, where a relative directory was implied. Whenever this is the case a 'MATLAB:cd:NonExistentDirectory' error is thrown. By adding additional logic for verifying the different cases this can be circumvented.