### PR TITLE
Patch function displayStack to give readable output also on command line

### DIFF
--- a/src/+xunit/displayStack.m
+++ b/src/+xunit/displayStack.m
@@ -8,11 +8,12 @@ function displayStack(stack, file_handle)
 
 if nargin < 2, file_handle = 1; end
 
+command_line_mode = ~ usejava('desktop');
+
 for k = 1:numel(stack)
     filename = stack(k).file;
     linenumber = stack(k).line;
-    terminalMode = ~ usejava('desktop');
-    if terminalMode
+    if command_line_mode
         fprintf(file_handle, '%s at line %d\n', filename, linenumber);
     else
         href = sprintf('matlab: opentoline(''%s'',%d)', filename, linenumber);

--- a/src/+xunit/displayStack.m
+++ b/src/+xunit/displayStack.m
@@ -11,7 +11,12 @@ if nargin < 2, file_handle = 1; end
 for k = 1:numel(stack)
     filename = stack(k).file;
     linenumber = stack(k).line;
-    href = sprintf('matlab: opentoline(''%s'',%d)', filename, linenumber);
-    fprintf(file_handle, '%s at <a href="%s">line %d</a>\n', filename, href, linenumber);
+    terminalMode = ~ usejava('desktop');
+    if terminalMode
+        fprintf(file_handle, '%s at line %d\n', filename, linenumber);
+    else
+        href = sprintf('matlab: opentoline(''%s'',%d)', filename, linenumber);
+        fprintf(file_handle, '%s at <a href="%s">line %d</a>\n', filename, href, linenumber);
+    end
 end
 end


### PR DESCRIPTION
- if errors are encountered while running xunit from the command line:
  - do not attempt to provide a clickable link to the offending line
  - instead: simply print the offending filename and line number

- background:
  - I like to run tests without the full MATLAB interface
  - but the output used to look like that 
![image](https://cloud.githubusercontent.com/assets/6757489/24694357/d52d2076-19e1-11e7-8613-8b4d82b14cda.png)
  - now it looks like that 
![image](https://cloud.githubusercontent.com/assets/6757489/24694405/02943ef0-19e2-11e7-8e4b-dd3acc2dc346.png)

