### PR TITLE
Fix a test failure in TestSuiteTest:test_fromName_with_relative_dirname_on_path on R2012a

### DIFF
--- a/tests/TestSuiteTest.m
+++ b/tests/TestSuiteTest.m
@@ -99,15 +99,17 @@ classdef TestSuiteTest < TestCaseInDir
 
       function test_fromName_with_relative_dirname_on_path(self)
          % Passing a partial directory name that is on the MATLAB path will
-         % cause a crash if not handled properly, see #14. The 'matlab' package
-         % here is used as that will exist multiple times with respect to
-         % `what` used internally. The case for relative paths is implicitly
-         % tested, as that will make other tests in the test suite of this
-         % package fail.
-         suite = TestSuite.fromName('matlab');
+         % cause a crash if not handled properly, see #14. The
+         % 'add_to_path' directory is temporarily added to the path while
+         % this test executes from 'helper_classes'.
+         test_dir = fullfile(fileparts(mfilename('fullpath')), 'add_to_path');
+         addpath(test_dir);
+         path_cleanup = onCleanup(@() rmpath(test_dir));
+         
+         suite = TestSuite.fromName('add_to_path');
 
-         assertEqual(suite.Name, 'matlab');
-         assertEqual(suite.Location, 'Package');
+         assertEqual(suite.Name, 'add_to_path');
+         assertEqual(suite.Location, '');
          assertEqual(numel(suite.TestComponents), 0);
       end
       


### PR DESCRIPTION
PR #16, the fix for #14, introduced a test failure on R2012a (Windows, 64-bit). "TestSuiteTest:test_fromName_with_relative_dirname_on_path" fails with the message below because matlab.system.CoreBlockSystem contains an error:

> The specified super-class 'matlab.system.BlockCore' contains a parse error or cannot be found on MATLAB's search path, possibly shadowed by another file with the same name.

I modified the test to use its own directory on the path, rather than assuming anything about MATLAB's internal packages. I verified that this version of the test fails in R2012a and R2017a when the fix for TestSuite.fromName is backed out. 