### PR TITLE
Added -throwerrors option to runxunit

### DIFF
--- a/src/TestComponent.m
+++ b/src/TestComponent.m
@@ -34,7 +34,7 @@ classdef TestComponent < handle
         
         %run Execute test cases
         %   obj.run() executes all the test cases in the test component
-        did_pass_out = run(self, monitor)
+        did_pass_out = run(self, monitor, throw)
         
         %numTestCases Number of test cases in test component
         num = numTestCases(self)

--- a/src/TestSuite.m
+++ b/src/TestSuite.m
@@ -66,7 +66,7 @@ classdef TestSuite < TestComponent
             end
         end
         
-        function did_pass_out = run(self, monitor)
+        function did_pass_out = run(self, monitor, throw)
             %run Execute test cases in test suite
             %   did_pass = suite.run() executes all test cases in the test
             %   suite, returning a logical value indicating whether or not all
@@ -76,13 +76,17 @@ classdef TestSuite < TestComponent
                 monitor = CommandWindowTestRunDisplay();
             end
             
+            if nargin < 3
+                throw = false;
+            end
+            
             monitor.testComponentStarted(self);
             did_pass = true;
             
             self.setUp();
             
             for k = 1:numel(self.TestComponents)
-                this_component_passed = self.TestComponents{k}.run(monitor);
+                this_component_passed = self.TestComponents{k}.run(monitor, throw);
                 did_pass = did_pass && this_component_passed;
             end
             

--- a/src/runxunit.m
+++ b/src/runxunit.m
@@ -41,6 +41,11 @@ function out = runxunit(varargin)
 %   Window.  This format is compatible with JUnit, and can be read by many
 %   tools.
 %
+%   runxunit(..., '-throwerrors') causes runxunit to throw errors when
+%   encountered rather than simply reporting them. Can be useful for
+%   debugging tests, or using tests for development, as well as a
+%   post-feature development tool.
+%
 %   out = runxunit(...) returns a logical value that is true if all the
 %   tests passed.
 %
@@ -89,7 +94,7 @@ isxml = false;
 if nargin < 1
     suite = TestSuite.fromPwd();
 else
-    [name_list, verbose, logfile, isxml] = getInputNames(varargin{:});
+    [name_list, verbose, logfile, isxml, throw] = getInputNames(varargin{:});
     if numel(name_list) == 0
         suite = TestSuite.fromPwd();
     elseif numel(name_list) == 1
@@ -133,17 +138,18 @@ elseif verbose
 else
     monitor = TestRunDisplay(logfile_handle);
 end
-did_pass = suite.run(monitor);
+did_pass = suite.run(monitor, throw);
 
 if nargout > 0
     out = did_pass;
 end
 
-function [name_list, verbose, logfile, isxml] = getInputNames(varargin)
+function [name_list, verbose, logfile, isxml, throw] = getInputNames(varargin)
 name_list = {};
 verbose = false;
 logfile = '';
 isxml = false;
+throw = false;
 k = 1;
 while k <= numel(varargin)
     arg = varargin{k};
@@ -169,6 +175,8 @@ while k <= numel(varargin)
                 logfile = varargin{k+1};
                 k = k + 1;
             end
+        elseif strcmp(arg, '-throwerrors')
+            throw = true;
         else
             warning('runxunit:unrecognizedOption', 'Unrecognized option: %s', arg);
         end


### PR DESCRIPTION
This PR adds an option `-throwerrors` to runxunit which defaults to false if not supplied. It used, then test cases will be run outside a try catch block. The purpose it to make it easier to debug test cases, and use test cases for development of features.