### PR TITLE
fix: Compatibility with 2023b and newer

### DIFF
--- a/src/+xunit/+private/getDecimalMatlabVersion.m
+++ b/src/+xunit/+private/getDecimalMatlabVersion.m
@@ -1,5 +1,5 @@
-function matlabVersion = getMatlabVersion()
-%GETMATLABVERSION Returns MATLAB's version, as a double
+function decimalVersion = getDecimalMatlabVersion()
+%GETDECIMALMATLABVERSION Returns MATLAB's version, as a double
 %   For 2023b and newer, the integer part is the year, and the fractional
 %   part specifies the release number:
 %   * 2023b = 23.2
@@ -19,7 +19,6 @@ function matlabVersion = getMatlabVersion()
 % version returns a string like "23.2.0.2599560 (R2023b) Update 8", which
 % we can convert to a numerically comparable form by keeping only the part
 % before the second period.
-matlabVersion = str2double(regexp(version, '^\d+\.\d+', 'match', 'once'));
+decimalVersion = str2double(regexp(version, '^\d+\.\d+', 'match', 'once'));
 
 end
-

--- a/src/+xunit/+private/getMatlabVersion.m
+++ b/src/+xunit/+private/getMatlabVersion.m
@@ -1,0 +1,25 @@
+function matlabVersion = getMatlabVersion()
+%GETMATLABVERSION Returns MATLAB's version, as a double
+%   For 2023b and newer, the integer part is the year, and the fractional
+%   part specifies the release number:
+%   * 2023b = 23.2
+%   * 2024a = 24.1
+%   For 2023a and older, it's more arbitary, but lookup tables can be found
+%   online:
+%   * 2012b = 8.0
+%   * 2013b = 8.2
+%   * 2016a = 9.0
+%   * 2023a = 9.14
+
+% There are 4 commands that can be used to compute the MATLAB release
+% version: ver, version, matlabRelease, and isMATLABReleaseOlderThan.
+% isMATLABReleaseOlderThan is what we what, but it was only added in 202b,
+% along with matlabRelease, so those are out. ver is not recommended for
+% use in 2023b or newer. So that leaves version. 
+% version returns a string like "23.2.0.2599560 (R2023b) Update 8", which
+% we can convert to a numerically comparable form by keeping only the part
+% before the second period.
+matlabVersion = str2double(regexp(version, '^\d+\.\d+', 'match', 'once'));
+
+end
+

--- a/src/initTestSuite.m
+++ b/src/initTestSuite.m
@@ -7,8 +7,7 @@ feedback = {
     '`initTestSuite` script will be removed in the next major release.']
     };
 
-matlabVersionInfo = ver('matlab');
-if str2double(matlabVersionInfo.Version) >= 9.1 % R2016b and later
+if(xunit.private.getMatlabVersion >= 9.1) % R2016b and later
     error(feedback{:});
 else
     warning(feedback{:});

--- a/src/initTestSuite.m
+++ b/src/initTestSuite.m
@@ -7,7 +7,7 @@ feedback = {
     '`initTestSuite` script will be removed in the next major release.']
     };
 
-if(xunit.private.getMatlabVersion >= 9.1) % R2016b and later
+if(xunit.private.getDecimalMatlabVersion() >= 9.1) % R2016b and later
     error(feedback{:});
 else
     warning(feedback{:});

--- a/src/xml_read.m
+++ b/src/xml_read.m
@@ -91,9 +91,7 @@ tree            = [];
 RootName        = [];
 
 %% Check Matlab Version
-v = ver('MATLAB');
-version = str2double(regexp(v.Version, '\d.\d','match','once'));
-if (version<7.1)
+if (xunit.private.getMatlabVersion < 7.1)
   error('Your MATLAB version is too old. You need version 7.1 or newer.');
 end
 

--- a/src/xml_read.m
+++ b/src/xml_read.m
@@ -91,7 +91,7 @@ tree            = [];
 RootName        = [];
 
 %% Check Matlab Version
-if (xunit.private.getMatlabVersion < 7.1)
+if (xunit.private.getDecimalMatlabVersion() < 7.1)
   error('Your MATLAB version is too old. You need version 7.1 or newer.');
 end
 

--- a/src/xml_write.m
+++ b/src/xml_write.m
@@ -85,7 +85,7 @@ function DOMnode = xml_write(filename, tree, RootName, Pref)
 % Written by Jarek Tuszynski, SAIC, jaroslaw.w.tuszynski_at_saic.com
 
 %% Check Matlab Version
-if (xunit.private.getMatlabVersion < 7.0)
+if (xunit.private.getDecimalMatlabVersion() < 7.0)
   error('Your MATLAB version is too old. You need version 7.0 or newer.');
 end
 

--- a/src/xml_write.m
+++ b/src/xml_write.m
@@ -85,9 +85,7 @@ function DOMnode = xml_write(filename, tree, RootName, Pref)
 % Written by Jarek Tuszynski, SAIC, jaroslaw.w.tuszynski_at_saic.com
 
 %% Check Matlab Version
-v = ver('MATLAB');
-v = str2double(regexp(v.Version, '\d.\d','match','once'));
-if (v<7)
+if (xunit.private.getMatlabVersion < 7.0)
   error('Your MATLAB version is too old. You need version 7.0 or newer.');
 end
 

--- a/tests/TestInitTestSuite.m
+++ b/tests/TestInitTestSuite.m
@@ -1,8 +1,7 @@
 classdef TestInitTestSuite < TestCase
   methods (Static, Access = private)
     function version = getDecimalMatlabVersion()
-      matlabVersionInfo = ver('matlab');
-      version = str2double(matlabVersionInfo.Version);
+      version = xunit.private.getMatlabVersion();
     end
 
     function cleanupHandle = moveToTestDir()

--- a/tests/TestInitTestSuite.m
+++ b/tests/TestInitTestSuite.m
@@ -1,7 +1,7 @@
 classdef TestInitTestSuite < TestCase
   methods (Static, Access = private)
     function version = getDecimalMatlabVersion()
-      version = xunit.private.getMatlabVersion();
+      version = xunit.private.getDecimalMatlabVersion();
     end
 
     function cleanupHandle = moveToTestDir()


### PR DESCRIPTION
# Problem
The version regex used to parse the MATLAB release version was 
```
str2double(regexp(v.Version, '\d.\d','match','once'))
```
This is only extracting the final digit of the first integer part. It works fine on a version like `9.2`, but incorrectly parses `23.2` as `3.2`. This caused `xml_read` and `xml_write` to err out, thinking the version was much too old.

# Fix
Use the correct regex `'^\d+\.\d+'`, and add it in a new private function `xunit.private.getDecimalMatlabVersion`. Refactor existing usages of `ver` to use this instead.

Fixes #28 